### PR TITLE
PR 144: [BUG]: Fix bHidden updates and general context, allow some interaction with notification and force one app-instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -500,7 +500,9 @@ async function GetMessageData( uri )
         const entries = json.split( '\n' );
         for ( let i = 0; i < entries.length; i++ )
         {
-            jsonArr.push( entries[ i ] );
+            if('' !== entries[ i ].trim()) {
+                jsonArr.push( entries[ i ] );
+            }            
         }
 
         /**
@@ -512,7 +514,7 @@ async function GetMessageData( uri )
             return el !== null && el !== '';
         });
 
-        return jsonResult;
+        return jsonArr.length === 0 ? null : jsonResult;
     }
     catch ( err )
     {
@@ -667,8 +669,10 @@ async function GetMessages( )
 
     if ( Utils.isJsonString( json ) === false )
     {
+        Log.info( `core`, chalk.yellow( `[invalid response]` ), chalk.white( `:  ${json}` ), chalk.blueBright( `<query>` ), chalk.gray( `${ uri }` ));
+
         Log.error( `core`, chalk.redBright( `[messages]` ), chalk.white( `:  ` ),
-            chalk.redBright( `<msg>` ), chalk.gray( `Polling for new messages returned invalid json; skipping fetch. Change your instance URL to a valid ntfy instance.` ),
+            chalk.redBright( `<msg>` ), chalk.gray( `Polling for new messages returned invalid json (2); skipping fetch. Change your instance URL to a valid ntfy instance.` ),
             chalk.redBright( `<func>` ), chalk.gray( `GetMessages()` ) );
 
         return;
@@ -703,6 +707,7 @@ async function GetMessages( )
         const expires = object.expires;
         const message = object.message;
         const topic = object.topic;
+        const url = object.click || null;
 
         /**
             Auth Error > 401
@@ -772,6 +777,7 @@ async function GetMessages( )
             chalk.blueBright( `<msg>` ), chalk.gray( `Pending messages received` ),
             chalk.blueBright( `<type>` ), chalk.gray( `${ type }` ),
             chalk.blueBright( `<id>` ), chalk.gray( `${ id }` ),
+            chalk.blueBright( `<url>` ), chalk.gray( `${ url }` ),
             chalk.blueBright( `<status>` ), chalk.gray( `${ msgStatus }` ) );
 
         /**
@@ -783,14 +789,43 @@ async function GetMessages( )
 
         if ( !msgHistory.includes( id ) )
         {
+            Log.info( `core`, chalk.yellow( `[toast:notify]` ), chalk.white( `:  ` ),
+                    chalk.blueBright( `<object>` ), chalk.gray( `${ object }` ));
+
             toasted.notify({
                 title: `${ topic } - ${ dateHuman }`,
                 subtitle: `${ dateHuman }`,
                 message: `${ message }`,
                 sound: 'Pop',
-                open: cfgInstanceURL,
+                open: url || cfgInstanceURL,
                 persistent: cfgPersistent,
-                sticky: cfgPersistent
+                sticky: cfgPersistent,
+                wait: true
+            },
+            ( error, response ) =>
+            {
+                Log.info( `core`, chalk.yellow( `[toast:response]` ), chalk.white( `:  ` ),
+                    chalk.blueBright( `<response>` ), chalk.gray( `${ response }` ),
+                    chalk.blueBright( `<error>` ), chalk.gray( `${ error }` ),
+                    chalk.blueBright( `<bWinHidden>` ), chalk.gray( `${ bWinHidden }` ));
+                    
+                if ( bWinHidden )
+                {
+                    bWinHidden = 0;
+                }
+                if (guiMain.isMinimized()) guiMain.restore();
+                guiMain.show();
+                if(url)shell.openExternal(url);
+            });
+
+            toasted.on('click', function (obj, options, event) {
+                // Triggers if `wait: true` and user clicks notification
+                Log.info( `core`, chalk.yellow( `[toast:clicked]` ), chalk.white( `:  ` ),
+                    chalk.blueBright( `<obj>` ), chalk.gray( `${ obj }` ),
+                    chalk.blueBright( `<options>` ), chalk.gray( `${ options }` ),
+                    chalk.blueBright( `<event>` ), chalk.gray( `${ event }` ) );
+
+                    guiMain.show();
             });
 
             msgHistory.push( id );
@@ -1098,6 +1133,7 @@ function ready()
     {
         store.set( 'indicatorMessages', 0 );
         app.badgeCount = 0;
+        bWinHidden = 0;
     });
 
     /**
@@ -1118,6 +1154,7 @@ function ready()
             }
             else
             {
+                bWinHidden = 1;
                 guiMain.hide();
             }
         }
@@ -1144,6 +1181,16 @@ function ready()
     {
         e.preventDefault();
         shell.openExternal( url );
+    });
+
+    /**
+        Event > Minimize
+    */
+    guiMain.on("minimize", () => {
+        Log.info( `core`, chalk.yellow( `[minimize]` ), chalk.white( `:  ` ),
+            chalk.blueBright( `<msg>` ), chalk.gray( `App has been minimized - update bWinHidden var` ) );
+
+        bWinHidden = 1;
     });
 
     /**
@@ -1292,6 +1339,9 @@ function ready()
     guiTray.setContextMenu( menuTray );
     guiTray.on( 'click', () =>
     {
+        Log.info( `core`, chalk.yellow( `[contextMenu:click]` ), chalk.white( `:  ` ),
+            chalk.blueBright( `<bWinHidden>` ), chalk.gray( `${ bWinHidden }` ));
+
         if ( bWinHidden )
         {
             bWinHidden = 0;
@@ -1518,6 +1568,26 @@ app.on( 'activate', () =>
     if ( BrowserWindow.getAllWindows().length === 0 )
         ready();
 });
+
+
+/**
+    App > Do not allow multiple instances
+*/
+const gotTheLock = app.requestSingleInstanceLock();
+if (!gotTheLock) {
+    gracefulShutdown();
+} else {
+    app.on("second-instance", () => {
+
+    if (!guiMain) return;
+    
+    Log.info( `core`, chalk.yellow( `[second-instance]` ), chalk.white( `:  ` ),
+            chalk.blueBright( `<msg>` ), chalk.gray( `App re-open: try to regain focus` ) );
+
+    if (guiMain.isMinimized()) guiMain.restore();
+    guiMain.focus();
+    });
+}
 
 /**
     ping functionality to announce signals from renderer

--- a/src/package.json
+++ b/src/package.json
@@ -114,7 +114,7 @@
         "@vitest/ui": "^1.6.0",
         "all-contributors-cli": "^6.26.1",
         "codecov": "^3.8.3",
-        "electron": "^37.0.0",
+        "electron": "^37.10.2",
         "electron-playwright-helpers": "^1.7.1",
         "env-cmd": "^10.1.0",
         "eslint": "9.29.0",


### PR DESCRIPTION
# Fix bHidden updates and general context

- [X] Bug

sometimes the "bHidden" variable - which is a global variable tracking the main window visibility status - is not correctly updated, especially when reacting on some events such as "minimize window", "minimize to tray" and/or when changing the visibility on user interacton from different locations;

now the variable should be properly updated and reactive, and the Windows visibility should change instantly;

---

# Allow some interaction with notification

- [X] Feature

 Now when a notification is showed after a successfull polling request, that notification has been modified to be able to:

- since a NTFY message can have a "click" attribute (which should be an absolute URL), clicking on the notification will open the default browser (and not in electron); this only when the "click" variable exist in the payload and is not null or an empty string;

- clicking on the notification will try to show (or wake up) the main window (as expected);

---

# Force only one app instance at any time

- [X] Feature

Since most users are not tech-guys they usually open the application several times, and this causes a lot of issues;
Yes, this could be mitigate with the option "Always quit app" but is not very convenient, especially if You want every user to receive notifications even when they are not using the PC;

so basically now - since is possibile via Electron - the workflow will take care to allow only one instance of Ntfy-Desktop;

