### PR TITLE
feat: preserve custom instance when offline and auto-reconnect (#152)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -248,6 +248,8 @@ let statusBadURL = false;                           // user instance url entered
 let statusStrMsg;                                   // string status message
 let isShuttingDown = false;                         // determine if app is currently attempting to shut down
 let pollInterval = null;                            // store interval reference for proper cleanup
+let instanceReconnectTimer = null;                  // background reconnect timer used while the instance is unreachable
+let offlinePageShown = false;                        // whether the local offline page is currently displayed
 
 /**
     Define > Default Fallbacks
@@ -264,6 +266,7 @@ const defPollrate = 60;                             // default polling rate
 const minPollrate = 5;                              // minimum poll rate to prevent rate limiting
 const maxPollrate = 3600;                           // maximum poll rate (1 hour)
 const maxRetries = 3;                               // maximum retry attempts for network requests
+const instanceReconnectDelay = 15000;               // delay between background reconnect attempts while offline (issue #152)
 
 /**
     Define > Store Values
@@ -431,6 +434,113 @@ function IsValidUrl( uri, tries, delay )
                 setTimeout( () => rec( --tries ), delay );
             });
         })( tries );
+    });
+}
+
+/**
+    Instance > Reconnect timer cleanup
+
+    stops any pending background reconnect attempt. called on shutdown and when
+    the main window is closed so we never fire a retry against a destroyed window.
+*/
+
+function stopInstanceReconnect()
+{
+    if ( instanceReconnectTimer )
+    {
+        clearTimeout( instanceReconnectTimer );
+        instanceReconnectTimer = null;
+    }
+}
+
+/**
+    Instance > Show Offline Page
+
+    loads the bundled local offline page (works with no network) and injects the
+    unreachable instance url. shown while we cannot reach the configured instance.
+*/
+
+function showOfflinePage( targetUrl )
+{
+    if ( !guiMain || typeof guiMain.loadFile !== 'function' )
+        return;
+
+    offlinePageShown = true;
+
+    guiMain.loadFile( path.join( app.getAppPath(), `pages`, `offline.html` ) )
+        .then( () =>
+        {
+            if ( !guiMain || guiMain.webContents.isDestroyed() )
+                return;
+
+            guiMain.webContents.executeJavaScript(
+                `( () => { const el = document.getElementById( 'instance-url' ); if ( el ) el.textContent = ${ JSON.stringify( targetUrl ) }; })();`
+            ).catch( () => {});
+        })
+        .catch( ( err ) =>
+        {
+            Log.error( `core`, chalk.redBright( `[instance]` ), chalk.white( `:  ` ),
+                chalk.redBright( `<msg>` ), chalk.gray( `Failed to load offline page` ),
+                chalk.redBright( `<error>` ), chalk.gray( `${ err.message }` ) );
+        });
+}
+
+/**
+    Instance > Resolve & Load
+
+    validates the user's configured instance and loads it. if it cannot be
+    reached (e.g. the machine is offline at startup), we intentionally do NOT
+    overwrite the stored instanceURL or redirect to the public ntfy.sh instance;
+    doing so previously caused a private instance to be permanently forgotten
+    with no way to reconnect (issue #152).
+
+    instead we show a local offline page and keep retrying in the background.
+    once the instance becomes reachable we load it and clear statusBadURL, which
+    lets GetMessages() resume polling automatically.
+*/
+
+function resolveInstanceAndLoad()
+{
+    if ( !guiMain )
+        return;
+
+    const targetUrl = store.get( 'instanceURL' ) || defInstanceUrl;
+
+    IsValidUrl( targetUrl, maxRetries, 1000 ).then( () =>
+    {
+        stopInstanceReconnect();
+
+        statusBadURL = false;
+        statusBoolError = false;
+        statusStrMsg = '';
+        offlinePageShown = false;
+
+        Log.ok( `core`, chalk.yellow( `[instance]` ), chalk.white( `:  ` ),
+            chalk.greenBright( `<msg>` ), chalk.gray( `Specified instance successfully resolves` ),
+            chalk.greenBright( `<instance>` ), chalk.gray( `${ targetUrl }` ) );
+
+        if ( guiMain && typeof guiMain.loadURL === 'function' )
+            guiMain.loadURL( targetUrl );
+    }).catch( ( err ) =>
+    {
+        /*
+            keep the user's stored instanceURL intact so we can reconnect to it.
+        */
+
+        statusBadURL = true;                                                     // gates polling until the instance is reachable again
+        statusBoolError = true;
+        statusStrMsg = `Unable to reach ${ targetUrl } — you appear to be offline. Reconnecting automatically…`;
+
+        Log.error( `core`, chalk.redBright( `[instance]` ), chalk.white( `:  ` ),
+            chalk.redBright( `<msg>` ), chalk.gray( `Failed to resolve instance url; keeping setting and retrying (offline?)` ),
+            chalk.redBright( `<error>` ), chalk.gray( `${ err.message }` ),
+            chalk.redBright( `<instance>` ), chalk.gray( `${ targetUrl }` ) );
+
+        if ( !offlinePageShown )
+            showOfflinePage( targetUrl );
+
+        stopInstanceReconnect();
+        instanceReconnectTimer = setTimeout( resolveInstanceAndLoad, instanceReconnectDelay );
     });
 }
 
@@ -1051,33 +1161,7 @@ function ready()
     }
     else
     {
-        IsValidUrl( instanceUrl, maxRetries, 1000 ).then( ( item ) =>
-        {
-            Log.ok( `core`, chalk.yellow( `[instance]` ), chalk.white( `:  ` ),
-                chalk.greenBright( `<msg>` ), chalk.gray( `Specified instance successfully resolves` ),
-                chalk.greenBright( `<instance>` ), chalk.gray( `${ instanceUrl }` ) );
-
-            statusBadURL = false;
-            guiMain.loadURL( store.get( 'instanceURL' ) );
-        }).catch( ( err ) =>
-        {
-            Log.error( `core`, chalk.redBright( `[instance]` ), chalk.white( `:  ` ),
-                chalk.redBright( `<msg>` ), chalk.gray( `Failed to resolve instance url; switching to default` ),
-                chalk.redBright( `<error>` ), chalk.gray( `${ err.message }` ),
-                chalk.redBright( `<instanceBad>` ), chalk.gray( `${ instanceUrl }` ),
-                chalk.redBright( `<instanceDef>` ), chalk.gray( `${ defInstanceUrl }` ) );
-
-            statusBadURL = true;
-            statusStrMsg = `Failed to resolve ` + instanceUrl + `; defaulting to ${ defInstanceUrl }`;
-
-            store.set( 'instanceURL', defInstanceUrl );
-
-            // Check if guiMain is still valid before calling loadURL
-            if ( guiMain && typeof guiMain.loadURL === 'function' )
-            {
-                guiMain.loadURL( defInstanceUrl );
-            }
-        });
+        resolveInstanceAndLoad();
     }
 
 
@@ -1131,6 +1215,7 @@ function ready()
 
     guiMain.on( 'closed', () =>
     {
+        stopInstanceReconnect();
         guiMain = null;
     });
 
@@ -1458,6 +1543,12 @@ function gracefulShutdown()
         Log.info( `core`, chalk.yellow( `[shutdown]` ), chalk.white( `:  ` ),
             chalk.blueBright( `<msg>` ), chalk.gray( `Stopped message polling` ) );
     }
+
+    /**
+        stop any pending instance reconnect attempt
+    */
+
+    stopInstanceReconnect();
 
     /**
         set quit flag and exit

--- a/src/pages/offline.html
+++ b/src/pages/offline.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta http-equiv="content-type" content="text/html;charset=utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
+		<title>Offline</title>
+		<link href="css/bootstrap.min.css" rel="stylesheet">
+		<link rel="stylesheet" href="css/style.css?v=1.0.1">
+
+		<!--
+		Electron:	Line required for script imports
+					Add before all other JS files are loaded.
+		-->
+		<script>if (typeof module === 'object') {window.module = module; module = undefined;}</script>
+
+		<style>
+			html, body {
+				height: 100%;
+				margin: 0;
+				background-color: #212121;
+			}
+
+			.offline-wrap {
+				height: 100%;
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				text-align: center;
+				padding: 24px;
+				color: #FFFFFF;
+				font-weight: 100;
+			}
+
+			.offline-icon {
+				font-size: 54px;
+				line-height: 1;
+				margin-bottom: 18px;
+			}
+
+			.offline-title {
+				font-size: 1.5rem;
+				margin-bottom: 10px;
+			}
+
+			.offline-desc {
+				font-size: 0.95rem;
+				max-width: 460px;
+				color: #cfcfcf;
+				margin-bottom: 6px;
+			}
+
+			#instance-url {
+				color: #ffffff;
+				word-break: break-all;
+			}
+
+			.offline-retry {
+				margin-top: 22px;
+				font-size: 0.85rem;
+				color: #9a9a9a;
+			}
+
+			.offline-spinner {
+				width: 18px;
+				height: 18px;
+				border: 2px solid rgba(255, 255, 255, 0.25);
+				border-top-color: #ffffff;
+				border-radius: 50%;
+				display: inline-block;
+				vertical-align: middle;
+				margin-right: 8px;
+				animation: offline-spin 0.9s linear infinite;
+			}
+
+			@keyframes offline-spin {
+				to { transform: rotate(360deg); }
+			}
+		</style>
+	</head>
+
+	<body>
+		<div class="offline-wrap">
+			<div class="offline-icon">📡</div>
+			<div class="offline-title">You appear to be offline</div>
+			<div class="offline-desc">Unable to reach your ntfy instance:</div>
+			<div class="offline-desc"><span id="instance-url">your instance</span></div>
+			<div class="offline-retry"><span class="offline-spinner"></span>Reconnecting automatically&hellip;</div>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
## Summary

Fixes #152 — when the machine is offline (or wifi hasn't connected yet) at startup, the app would fall back to `https://ntfy.sh/app` **and permanently overwrite the user's configured instance URL**, so a private instance was lost and never reconnected even after the network returned.

## Root cause

In `src/index.js`, the instance-resolution `.catch` did:

```js
statusBadURL = true;                      // blocks polling, with no retry
store.set( 'instanceURL', defInstanceUrl ); // destroys the user's private instance URL
guiMain.loadURL( defInstanceUrl );
```

So a transient network failure irreversibly erased the user's setting, and polling stayed disabled forever.

## Changes

- **Never overwrite the stored `instanceURL`** on a failed resolve — the user's configured instance is preserved.
- On failure, instead of hijacking to `ntfy.sh/app`, show a local **offline page** (`src/pages/offline.html`) that displays the unreachable instance and an "Reconnecting automatically…" indicator.
- **Retry the configured instance in the background** (every 15s). Once it becomes reachable, load it and clear the error flag so message polling resumes automatically.
- Reconnect timer is cleaned up on window close and on graceful shutdown.

This matches the behavior requested in the issue (offline banner + auto-reconnect, no silent fallback), and also covers the default-instance user (offline → offline page → loads `ntfy.sh/app` once reachable).

<img width="1766" height="1042" alt="Screenshot_20260702_180400" src="https://github.com/user-attachments/assets/52f91397-e52b-46cd-97a6-2568d036d9a0" />

## Testing

- `npm run lint` — the changed `index.js` is clean.
- `npm run test:unit:run` — 78/78 unit tests pass.
- Manual, offline (unreachable instance): instance URL **preserved** in `prefs.json`, offline page shown, background retry fires every ~15s, no destructive "defaulting" fallback.
- Manual, reachable private instance: resolves and loads, polling starts, renderer injected.

## Notes

- Scope is intentionally limited to the offline/reconnect fix (two files: `src/index.js`, `src/pages/offline.html`).
- Reconnect interval is a fixed 15s; happy to switch to a backoff if preferred.
