### PR TITLE
feat: bridge web app notifications to native for all-topic coverage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@
 
 import { app, BrowserWindow, dialog, ipcMain, Tray, shell, Menu, MenuItem, nativeImage } from 'electron';
 import path from 'path';
+import os from 'os';
+import crypto from 'crypto';
 import moment from 'moment';
 import chalk from 'chalk';
 import fs from 'fs';
@@ -802,10 +804,17 @@ async function GetMessages( )
 
         if ( !msgHistory.includes( id ) )
         {
+            /*
+                use the message icon when the publisher set one; otherwise the bundled default
+            */
+
+            const icon = await resolveNotificationIcon( object.icon ? String( object.icon ) : '' );
+
             toasted.notify({
                 title: `${ topic } - ${ dateHuman }`,
                 subtitle: `${ dateHuman }`,
                 message: `${ message }`,
+                icon,
                 'app-name': `${ topic }`,
                 sound: 'Pop',
                 open: cfgInstanceURL,
@@ -1628,7 +1637,84 @@ ipcMain.on( 'button-clicked', ( event, data ) =>
     later — without maintaining a separate poll-topics list.
 */
 
-ipcMain.on( 'web-notification', ( event, data ) =>
+/**
+    resolve a notification icon to a local file path
+
+    native notifiers (notify-send on linux, SnoreToast on windows) cannot load remote
+    http(s) urls — they require a local file path. so download a remote icon url once,
+    cache it in the temp dir (keyed by a hash of the url) and reuse it on subsequent
+    notifications. anything that isn't an http(s) url, plus any failure/timeout, falls
+    back to the bundled ntfy icon so a notification is never blocked by icon resolution.
+*/
+
+async function resolveNotificationIcon( iconUrl )
+{
+    if ( !iconUrl || !/^https?:\/\//i.test( iconUrl ) )
+        return appIcon;
+
+    try
+    {
+        const cacheDir = path.join( os.tmpdir(), 'ntfy-desktop-icons' );
+        if ( !fs.existsSync( cacheDir ) )
+            fs.mkdirSync( cacheDir, { recursive: true });
+
+        const hash = crypto.createHash( 'sha1' ).update( iconUrl ).digest( 'hex' );
+        const extMatch = iconUrl.match( /\.(png|jpe?g|gif|webp|svg|ico)(?:[?#]|$)/i );
+        const ext = extMatch ? extMatch[ 1 ] : 'png';
+        const filePath = path.join( cacheDir, `${ hash }.${ ext }` );
+
+        /*
+            cache hit — reuse the previously downloaded icon
+        */
+
+        if ( fs.existsSync( filePath ) )
+            return filePath;
+
+        /*
+            download with a short timeout so a slow host never hangs the popup
+        */
+
+        const controller = new AbortController();
+        const timer = setTimeout( () => controller.abort(), 3000 );
+
+        let res;
+        try
+        {
+            res = await fetch( iconUrl, { signal: controller.signal });
+        }
+        finally
+        {
+            clearTimeout( timer );
+        }
+
+        if ( !res.ok )
+            return appIcon;
+
+        const buf = Buffer.from( await res.arrayBuffer() );
+
+        /*
+            sanity size guard (5 MB)
+        */
+
+        if ( buf.length > 5 * 1024 * 1024 )
+            return appIcon;
+
+        fs.writeFileSync( filePath, buf );
+
+        return filePath;
+    }
+    catch ( e )
+    {
+        Log.debug( `ipc`, chalk.yellow( `[web-notification]` ), chalk.white( `:  ` ),
+            chalk.blueBright( `<msg>` ), chalk.gray( `Icon download failed; using default icon` ),
+            chalk.blueBright( `<url>` ), chalk.gray( `${ iconUrl }` ),
+            chalk.blueBright( `<error>` ), chalk.red( `${ e.message }` ) );
+
+        return appIcon;
+    }
+}
+
+ipcMain.on( 'web-notification', async( event, data ) =>
 {
     const title = ( data && data.title ) ? String( data.title ) : appTitle;
     const message = ( data && data.body ) ? String( data.body ) : '';
@@ -1658,9 +1744,17 @@ ipcMain.on( 'web-notification', ( event, data ) =>
 
     const cfgPersistent = store.getInt( 'bPersistentNoti' ) !== 0;
 
+    /*
+        use the message icon when the publisher set one; otherwise the bundled default
+    */
+
+    const iconUrl = ( data && data.icon ) ? String( data.icon ) : '';
+    const icon = await resolveNotificationIcon( iconUrl );
+
     toasted.notify({
         title,
         message,
+        icon,
         'app-name': notificationTitle,
         sound: 'Pop',
         open: store.get( 'instanceURL' ),
@@ -1674,7 +1768,8 @@ ipcMain.on( 'web-notification', ( event, data ) =>
         chalk.blueBright( `<msg>` ), chalk.gray( `Forwarded web app notification to native notifier` ),
         chalk.blueBright( `<title>` ), chalk.gray( `${ title }` ),
         chalk.blueBright( `<notificationTitle>` ), chalk.gray( `${ notificationTitle }` ),
-        chalk.blueBright( `<displayName>` ), chalk.gray( `${ displayName || '(none)' }` ) );
+        chalk.blueBright( `<displayName>` ), chalk.gray( `${ displayName || '(none)' }` ),
+        chalk.blueBright( `<icon>` ), chalk.gray( `${ icon }` ) );
 });
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -806,6 +806,7 @@ async function GetMessages( )
                 title: `${ topic } - ${ dateHuman }`,
                 subtitle: `${ dateHuman }`,
                 message: `${ message }`,
+                'app-name': `${ topic }`,
                 sound: 'Pop',
                 open: cfgInstanceURL,
                 persistent: cfgPersistent,
@@ -1631,6 +1632,22 @@ ipcMain.on( 'web-notification', ( event, data ) =>
 {
     const title = ( data && data.title ) ? String( data.title ) : appTitle;
     const message = ( data && data.body ) ? String( data.body ) : '';
+    /*
+        the forwarded topic may arrive as a full subscription url
+        (e.g. https://ntfy.example.com/tugtainer); reduce it to just the
+        topic name (the last path segment) for a clean notification label.
+    */
+
+    const topicRaw = ( data && data.topic ) ? String( data.topic ) : '';
+    const topicName = topicRaw.replace( /\/+$/, '' ).split( '/' ).pop() || topicRaw;
+
+    /*
+        label the notification with the user-assigned per-topic display name when
+        present; otherwise fall back to the plain topic name.
+    */
+
+    const displayName = ( data && data.displayName ) ? String( data.displayName ) : '';
+    const notificationTitle = displayName || topicName;
 
     /*
         ignore empty notifications
@@ -1644,6 +1661,7 @@ ipcMain.on( 'web-notification', ( event, data ) =>
     toasted.notify({
         title,
         message,
+        'app-name': notificationTitle,
         sound: 'Pop',
         open: store.get( 'instanceURL' ),
         persistent: cfgPersistent,
@@ -1654,7 +1672,9 @@ ipcMain.on( 'web-notification', ( event, data ) =>
 
     Log.debug( `ipc`, chalk.yellow( `[web-notification]` ), chalk.white( `:  ` ),
         chalk.blueBright( `<msg>` ), chalk.gray( `Forwarded web app notification to native notifier` ),
-        chalk.blueBright( `<title>` ), chalk.gray( `${ title }` ) );
+        chalk.blueBright( `<title>` ), chalk.gray( `${ title }` ),
+        chalk.blueBright( `<notificationTitle>` ), chalk.gray( `${ notificationTitle }` ),
+        chalk.blueBright( `<displayName>` ), chalk.gray( `${ displayName || '(none)' }` ) );
 });
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1154,6 +1154,27 @@ function ready()
     });
 
     /**
+        Event > Show / Hide
+
+        push the real window visibility to the injected renderer so the notification
+        bridge can mirror it into document.hidden / visibilityState. while the app sits
+        in the tray (hidden) the ntfy web app will emit notifications, which we forward
+        to the native notifier; when the window is shown we report visible so it behaves
+        normally.
+    */
+
+    const sendWindowVisibility = ( hidden ) =>
+    {
+        if ( guiMain && guiMain.webContents && !guiMain.webContents.isDestroyed() )
+            guiMain.webContents.send( 'fromMain', { type: 'window-visibility', hidden });
+    };
+
+    guiMain.on( 'show', () => sendWindowVisibility( false ) );
+    guiMain.on( 'hide', () => sendWindowVisibility( true ) );
+    guiMain.on( 'focus', () => sendWindowVisibility( false ) );
+    guiMain.on( 'minimize', () => sendWindowVisibility( true ) );
+
+    /**
         Event > New Window
 
         buttons leading to external websites should open in user browser
@@ -1172,6 +1193,13 @@ function ready()
 
     guiMain.webContents.on( 'did-finish-load', ( e, url ) =>
     {
+        /*
+            report the accurate initial window visibility to the notification bridge
+            once the renderer (and its 'fromMain' listener) has loaded.
+        */
+
+        sendWindowVisibility( !guiMain.isVisible() );
+
         if ( ( statusBoolError === true || statusBadURL === true ) && statusStrMsg !== '' )
         {
             guiMain.webContents
@@ -1586,6 +1614,47 @@ ipcMain.on( 'button-clicked', ( event, data ) =>
     Log.debug( `badge`, chalk.yellow( `[reset]` ), chalk.white( `:  ` ),
         chalk.greenBright( `<msg>` ), chalk.gray( `Badge count reset to 0` ),
         chalk.greenBright( `<trigger>` ), chalk.gray( `MuiButtonBase-root click detected` ) );
+});
+
+/**
+    ipc > renderer > native notification bridge
+
+    the injected renderer intercepts the ntfy web app's own Web Notifications and
+    forwards them here so we can display them through the native notifier
+    (toasted-notifier / notify-send), which integrates with the desktop notification
+    server. because this rides on the web app's live subscriptions, it delivers a
+    desktop popup for every topic the user is subscribed to — including topics added
+    later — without maintaining a separate poll-topics list.
+*/
+
+ipcMain.on( 'web-notification', ( event, data ) =>
+{
+    const title = ( data && data.title ) ? String( data.title ) : appTitle;
+    const message = ( data && data.body ) ? String( data.body ) : '';
+
+    /*
+        ignore empty notifications
+    */
+
+    if ( ( !data || !data.title ) && message === '' )
+        return;
+
+    const cfgPersistent = store.getInt( 'bPersistentNoti' ) !== 0;
+
+    toasted.notify({
+        title,
+        message,
+        sound: 'Pop',
+        open: store.get( 'instanceURL' ),
+        persistent: cfgPersistent,
+        sticky: cfgPersistent
+    });
+
+    UpdateBadge();
+
+    Log.debug( `ipc`, chalk.yellow( `[web-notification]` ), chalk.white( `:  ` ),
+        chalk.blueBright( `<msg>` ), chalk.gray( `Forwarded web app notification to native notifier` ),
+        chalk.blueBright( `<title>` ), chalk.gray( `${ title }` ) );
 });
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,6 @@ import toasted from 'toasted-notifier';
 import prompt from 'electron-plugin-prompts';
 import Log from './classes/Log.js';
 import Storage from './classes/Storage.js';
-import Utils from './classes/Utils.js';
 import { fileURLToPath } from 'url';
 import { newMenuMain, newMenuContext, setMenuDeps } from './classes/Menu.js';
 
@@ -662,14 +661,20 @@ async function GetMessages( )
     }
 
     /**
-        will be thrown if the instance url does not return valid json (ntfy server possibly down?)
+        GetMessageData() returns an array of per-message json strings (or null on
+        failure, which is handled above). an empty array simply means this poll
+        returned no new messages, so there is nothing to process.
+
+        note: this previously called Utils.isJsonString( json ) on the array, which
+        coerced it to a comma-joined string. that only parsed as valid json when the
+        array held exactly one entry, so any poll containing two or more messages was
+        silently dropped. each entry is now validated individually in the loop below.
     */
 
-    if ( Utils.isJsonString( json ) === false )
+    if ( !Array.isArray( json ) || json.length === 0 )
     {
-        Log.error( `core`, chalk.redBright( `[messages]` ), chalk.white( `:  ` ),
-            chalk.redBright( `<msg>` ), chalk.gray( `Polling for new messages returned invalid json; skipping fetch. Change your instance URL to a valid ntfy instance.` ),
-            chalk.redBright( `<func>` ), chalk.gray( `GetMessages()` ) );
+        Log.debug( `core`, chalk.yellow( `[messages]` ), chalk.white( `:  ` ),
+            chalk.blueBright( `<msg>` ), chalk.gray( `No new messages returned by poll` ) );
 
         return;
     }
@@ -696,7 +701,21 @@ async function GetMessages( )
 
     for ( let i = 0; i < json.length; i++ )
     {
-        const object = JSON.parse( json[ i ] );
+        let object;
+        try
+        {
+            object = JSON.parse( json[ i ] );
+        }
+        catch ( err )
+        {
+            Log.warn( `core`, chalk.yellow( `[messages]` ), chalk.white( `:  ` ),
+                chalk.yellowBright( `<msg>` ), chalk.gray( `Skipping malformed message entry` ),
+                chalk.yellowBright( `<error>` ), chalk.gray( `${ err.message }` ),
+                chalk.yellowBright( `<entry>` ), chalk.gray( `${ json[ i ] }` ) );
+
+            continue;
+        }
+
         const id = object.id;
         const type = object.event;
         const time = object.time;

--- a/src/preload.js
+++ b/src/preload.js
@@ -42,7 +42,7 @@ contextBridge.exposeInMainWorld( 'electron',
             list of channels to allow for communication
         */
 
-        const allowChans = [ 'toMain', 'button-clicked' ];
+        const allowChans = [ 'toMain', 'button-clicked', 'web-notification' ];
         if ( allowChans.includes( chan ) )
             ipcRenderer.send( chan, data );
     },

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -836,5 +836,178 @@ if ( typeof window !== 'undefined' )
     }
 }
 
+/**
+    Notification bridge
+
+    the ntfy web app receives messages for every topic it is subscribed to and calls
+    the Web Notification API to alert the user. inside electron those web notifications
+    do not reliably reach the desktop notification server, so the popup is missed even
+    though the web app plays its sound.
+
+    here we intercept the web app's own notifications (in the page's main world) and
+    forward them to the main process, which displays them through the native notifier
+    (toasted-notifier / notify-send). because this piggybacks on the web app's live
+    subscriptions, it covers every topic — including ones added in the future — with no
+    poll-topic list to maintain.
+
+    we also mirror the real window visibility (pushed from main; hidden while the app
+    sits in the tray) into document.hidden / visibilityState, so the web app actually
+    emits a notification instead of silently updating a "focused" UI.
+*/
+
+( function setupNotificationBridge()
+{
+    if ( typeof window === 'undefined' || window.__ntfyNotificationBridge )
+        return;
+
+    window.__ntfyNotificationBridge = true;
+
+    /*
+        track the real app window visibility. default to hidden because the app is
+        started in the tray; main pushes accurate updates on show/hide and after load.
+    */
+
+    let appHidden = true;
+
+    try
+    {
+        if ( typeof window.electron !== 'undefined' && window.electron.receiveFromMain )
+        {
+            window.electron.receiveFromMain( 'fromMain', ( msg ) =>
+            {
+                if ( msg && typeof msg === 'object' && msg.type === 'window-visibility' )
+                    appHidden = !!msg.hidden;
+            });
+        }
+    }
+    catch ( e ) {}
+
+    try
+    {
+        Object.defineProperty( document, 'hidden',
+        {
+            configurable: true,
+            get: () => appHidden
+        });
+
+        Object.defineProperty( document, 'visibilityState',
+        {
+            configurable: true,
+            get: () => ( appHidden ? 'hidden' : 'visible' )
+        });
+    }
+    catch ( e ) {}
+
+    /*
+        forward a notification's text to the main process, which shows it through the
+        native notifier (toasted-notifier / notify-send).
+    */
+
+    function forwardToNative( title, body )
+    {
+        try
+        {
+            if ( typeof window.electron !== 'undefined' && window.electron.sendToMain )
+            {
+                window.electron.sendToMain( 'web-notification',
+                {
+                    title: String( title ?? '' ),
+                    body: String( body ?? '' )
+                });
+            }
+        }
+        catch ( e ) {}
+    }
+
+    /*
+        primary path: the ntfy web app displays notifications through the service worker
+        registration (registration.showNotification), not the Notification constructor.
+        patch the prototype method — this catches every registration instance, including
+        ones obtained before this script ran — forward the text to the native notifier and
+        suppress the original call (which does not surface in electron) to avoid duplicates.
+    */
+
+    try
+    {
+        const swProto = ( typeof window.ServiceWorkerRegistration !== 'undefined' )
+            ? window.ServiceWorkerRegistration.prototype
+            : null;
+
+        if ( swProto && typeof swProto.showNotification === 'function' && !swProto.__ntfyPatched )
+        {
+            swProto.__ntfyPatched = true;
+
+            swProto.showNotification = function ( title, options )
+            {
+                options = options || {};
+                forwardToNative( title, options.body );
+
+                return Promise.resolve();
+            };
+        }
+    }
+    catch ( e ) {}
+
+    /*
+        secondary path: also replace window.Notification with a bridge in case any code
+        uses the constructor directly. constructing forwards to native and returns a
+        minimal Notification-compatible stub, so exactly one popup is shown (the native one).
+    */
+
+    const NativeNotification = window.Notification;
+
+    function NotificationBridge( title, options )
+    {
+        options = options || {};
+        forwardToNative( title, options.body );
+
+        this.title = title;
+        this.body = options.body;
+        this.onclick = null;
+        this.onclose = null;
+        this.onerror = null;
+        this.onshow = null;
+    }
+
+    NotificationBridge.prototype.close = function () {};
+    NotificationBridge.prototype.addEventListener = function () {};
+    NotificationBridge.prototype.removeEventListener = function () {};
+    NotificationBridge.prototype.dispatchEvent = function () { return false; };
+
+    NotificationBridge.requestPermission = function ( cb )
+    {
+        if ( typeof cb === 'function' )
+            cb( 'granted' );
+
+        return Promise.resolve( 'granted' );
+    };
+
+    Object.defineProperty( NotificationBridge, 'permission',
+    {
+        configurable: true,
+        get: () => 'granted'
+    });
+
+    NotificationBridge.maxActions = ( NativeNotification && NativeNotification.maxActions ) || 2;
+
+    try
+    {
+        Object.defineProperty( window, 'Notification',
+        {
+            configurable: true,
+            writable: true,
+            value: NotificationBridge
+        });
+    }
+    catch ( e )
+    {
+        try
+        {
+            window.Notification = NotificationBridge;
+        }
+        catch ( e2 ) {}
+    }
+})();
+
 // Explicitly return undefined to prevent cloning issues
 undefined;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -903,18 +903,169 @@ if ( typeof window !== 'undefined' )
         native notifier (toasted-notifier / notify-send).
     */
 
-    function forwardToNative( title, body )
+    /*
+        the ntfy web app only puts the topic in the notification title when a message
+        has no title of its own; otherwise the title holds the message title. the topic
+        is always carried on the notification's data payload, so dig it out from the
+        likely shapes so main can label the popup with the topic regardless.
+    */
+
+    function extractTopic( options )
     {
         try
         {
-            if ( typeof window.electron !== 'undefined' && window.electron.sendToMain )
+            const data = ( options && options.data ) ? options.data : {};
+
+            return ( data.message && data.message.topic )
+                || data.topic
+                || ( data.notification && data.notification.topic )
+                || ( data.subscription && data.subscription.topic )
+                || data.subscriptionId
+                || '';
+        }
+        catch ( e )
+        {
+            return '';
+        }
+    }
+
+    /*
+        the ntfy web app lets the user assign a per-topic "display name". it is not
+        included in the notification payload — the web app keeps it in its own IndexedDB
+        ("ntfy" database, "subscriptions" store, keyed by the subscription id, which is
+        the topic url carried on the notification as data.subscriptionId). look it up
+        there so the native popup can be labelled with the display name when one is set.
+    */
+
+    function ntfyDatabaseNames()
+    {
+        return new Promise( ( resolve ) =>
+        {
+            try
             {
-                window.electron.sendToMain( 'web-notification',
+                if ( typeof indexedDB.databases === 'function' )
                 {
-                    title: String( title ?? '' ),
-                    body: String( body ?? '' )
-                });
+                    indexedDB.databases()
+                        .then( ( dbs ) => resolve( ( dbs || [] )
+                            .map( ( d ) => d && d.name )
+                            .filter( ( n ) => n === 'ntfy' || ( typeof n === 'string' && n.indexOf( 'ntfy' ) === 0 ) ) ) )
+                        .catch( () => resolve( [ 'ntfy' ] ) );
+                }
+                else
+                {
+                    resolve( [ 'ntfy' ] );
+                }
             }
+            catch ( e )
+            {
+                resolve( [ 'ntfy' ] );
+            }
+        });
+    }
+
+    function displayNameFromDb( dbName, subscriptionId )
+    {
+        return new Promise( ( resolve ) =>
+        {
+            try
+            {
+                const req = indexedDB.open( dbName );
+
+                req.onerror = () => resolve( '' );
+
+                req.onsuccess = () =>
+                {
+                    const dbc = req.result;
+
+                    try
+                    {
+                        if ( !dbc.objectStoreNames.contains( 'subscriptions' ) )
+                        {
+                            resolve( '' );
+                            dbc.close();
+                            return;
+                        }
+
+                        const store = dbc.transaction( 'subscriptions', 'readonly' ).objectStore( 'subscriptions' );
+                        const getReq = store.get( subscriptionId );
+
+                        getReq.onsuccess = () =>
+                        {
+                            const rec = getReq.result;
+                            resolve( ( rec && rec.displayName ) ? String( rec.displayName ) : '' );
+                            dbc.close();
+                        };
+
+                        getReq.onerror = () =>
+                        {
+                            resolve( '' );
+                            dbc.close();
+                        };
+                    }
+                    catch ( e )
+                    {
+                        resolve( '' );
+
+                        try
+                        {
+                            dbc.close();
+                        }
+                        catch ( e2 ) {}
+                    }
+                };
+            }
+            catch ( e )
+            {
+                resolve( '' );
+            }
+        });
+    }
+
+    async function lookupDisplayName( subscriptionId )
+    {
+        if ( !subscriptionId || typeof indexedDB === 'undefined' )
+            return '';
+
+        const names = await ntfyDatabaseNames();
+
+        for ( const name of names )
+        {
+            const displayName = await displayNameFromDb( name, subscriptionId );
+            if ( displayName )
+                return displayName;
+        }
+
+        return '';
+    }
+
+    function forwardToNative( title, options )
+    {
+        options = options || {};
+
+        try
+        {
+            if ( typeof window.electron === 'undefined' || !window.electron.sendToMain )
+                return;
+
+            const data = ( options && options.data ) ? options.data : {};
+            const subscriptionId = data.subscriptionId || '';
+
+            const send = ( displayName ) =>
+            {
+                try
+                {
+                    window.electron.sendToMain( 'web-notification',
+                    {
+                        title: String( title ?? '' ),
+                        body: String( options.body ?? '' ),
+                        topic: String( extractTopic( options ) ?? '' ),
+                        displayName: String( displayName ?? '' )
+                    });
+                }
+                catch ( e ) {}
+            };
+
+            lookupDisplayName( subscriptionId ).then( send ).catch( () => send( '' ) );
         }
         catch ( e ) {}
     }
@@ -940,7 +1091,7 @@ if ( typeof window !== 'undefined' )
             swProto.showNotification = function ( title, options )
             {
                 options = options || {};
-                forwardToNative( title, options.body );
+                forwardToNative( title, options );
 
                 return Promise.resolve();
             };
@@ -959,7 +1110,7 @@ if ( typeof window !== 'undefined' )
     function NotificationBridge( title, options )
     {
         options = options || {};
-        forwardToNative( title, options.body );
+        forwardToNative( title, options );
 
         this.title = title;
         this.body = options.body;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1059,7 +1059,8 @@ if ( typeof window !== 'undefined' )
                         title: String( title ?? '' ),
                         body: String( options.body ?? '' ),
                         topic: String( extractTopic( options ) ?? '' ),
-                        displayName: String( displayName ?? '' )
+                        displayName: String( displayName ?? '' ),
+                        icon: String( ( data.message && data.message.icon ) || options.icon || '' )
                     });
                 }
                 catch ( e ) {}


### PR DESCRIPTION
## Summary

Delivers a reliable desktop notification for **every** subscribed topic by bridging the ntfy web app's own notifications to the native notifier, and improves the notification labelling and iconography.

Inside Electron, the web app's Web Notifications do not reliably reach the desktop notification server, so popups were missed even though the web app played its sound. Rather than maintaining a separate poll-topics list, this piggybacks on the web app's live subscriptions — so coverage automatically includes any topic added in the future.

## Changes

- **Bridge web app notifications to native for all-topic coverage** — the injected renderer intercepts the web app's `ServiceWorkerRegistration.showNotification` (and the `Notification` constructor as a fallback), forwards the payload to the main process over IPC, and suppresses the original call to avoid duplicates. The main process then shows it through the native notifier. Real window visibility is mirrored into `document.hidden` / `visibilityState` so the web app actually emits notifications while the app sits in the tray.
- **Deliver desktop notifications when a poll returns multiple messages** — fixes the poll path so every message in a batch is surfaced, not just the first.
- **Notification title defaults to the display name, falls back to the topic name** — the native popup's app-name is set to the topic's user-assigned display name (read from the web app's IndexedDB, searching per-account `ntfy*` databases), falling back to the plain topic name. This replaces the previous generic `notify-send` label.
- **Show the message icon on native notifications** — uses the publisher's `Icon:` header (carried on the payload as `data.message.icon`) as the notification icon, falling back to the bundled ntfy icon when none is set. Because native notifiers (`notify-send`, SnoreToast) cannot load remote URLs, remote icons are downloaded once and cached in the temp dir (keyed by a hash of the URL), with a 3s timeout and size guard so a slow/broken icon never blocks the popup. Applied to both the bridge and the legacy poll path.

## Testing

Verified locally on Linux (`notify-send` backend) with `LOG_LEVEL=6`: notifications for multiple topics — including titled messages, topics with assigned display names, and messages with/without/with-broken `Icon:` headers — surface correctly with the expected label and image. `eslint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
